### PR TITLE
Fix a warning in console when bridging font.name

### DIFF
--- a/ASValueTrackingSlider/ASValuePopUpView.m
+++ b/ASValueTrackingSlider/ASValuePopUpView.m
@@ -137,7 +137,7 @@ NSString *const SliderFillColorAnim = @"fillColor";
                               value:font
                               range:NSMakeRange(0, [_attributedString length])];
     
-    _textLayer.font = (__bridge CFTypeRef)(font.fontName);
+    _textLayer.font = CGFontCreateWithFontName((__bridge CFStringRef)font.fontName);
     _textLayer.fontSize = font.pointSize;
 }
 


### PR DESCRIPTION
Fix a CoreText warning during slide : 
CoreText note: Client requested name ".SFUI-Regular", it will get TimesNewRomanPSMT rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[UIFont systemFontOfSize:].